### PR TITLE
feat: rebuild netlify sites only

### DIFF
--- a/rebuild-sites-netlify-only/index.js
+++ b/rebuild-sites-netlify-only/index.js
@@ -1,0 +1,55 @@
+const axios = require('axios')
+const Bluebird = require('bluebird')
+
+const {
+  NETLIFY_ACCESS_TOKEN,
+} = process.env;
+
+
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function rebuildAllNetlifySites() {
+  let sitesList = []
+  let pageCount = 1
+  let hasNextPage = true;
+
+  // 1. Obtain a list of Netlify site IDs for sites that belong to the isomer team
+  while (hasNextPage) {
+    try {
+      // Get list of all repos within current page
+      const resp = await axios.get(`https://api.netlify.com/api/v1/sites?access_token=${NETLIFY_ACCESS_TOKEN}&filter=all&page=${pageCount}`)
+      hasNextPage = resp.headers.link.includes('next')
+      resp.data.forEach(site => {
+        // If site belongs to the isomer account, push it to the list of sites to rebuild
+        if (site.account_name === 'isomer') {
+          sitesList.push({siteId: site.site_id, siteName: site.name})
+        }
+      })
+
+      console.log(`Obtained ${resp.data.length} sites in page ${pageCount}`)
+      pageCount++
+    } catch (err) {
+      console.error(`An error occurred obtaining the list of Netlify site IDs ${siteId}: ${JSON.stringify(err)}`)
+      throw err
+    }
+  }
+
+  console.log(`Found ${sitesList.length} Netlify sites belonging to the Isomer account`)
+
+  // 2. Trigger a rebuild for each site
+  await Bluebird.each(sitesList, async ({siteId, siteName}) => {
+    try {
+      await axios.post(`https://api.netlify.com/api/v1/sites/${siteId}/builds?access_token=${NETLIFY_ACCESS_TOKEN}`)
+      console.log(`Successfully triggered the rebuild for site ${siteName} with ID: ${siteId}`)
+
+      // Sleep to prevent hitting API rate limits
+      await sleep(1000)
+    } catch (err) {
+      console.error(`An error occurred during the rebuild for site ${siteName} with ID: ${JSON.stringify(err)}`)
+    }
+  })
+}
+
+rebuildAllNetlifySites()

--- a/rebuild-sites-netlify-only/package-lock.json
+++ b/rebuild-sites-netlify-only/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "rebuild-sites-netlify-only",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  }
+}

--- a/rebuild-sites-netlify-only/package-lock.json
+++ b/rebuild-sites-netlify-only/package-lock.json
@@ -12,6 +12,11 @@
         "follow-redirects": "1.5.10"
       }
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/rebuild-sites-netlify-only/package.json
+++ b/rebuild-sites-netlify-only/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rebuild-sites-netlify-only",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.19.2"
+  }
+}

--- a/rebuild-sites-netlify-only/package.json
+++ b/rebuild-sites-netlify-only/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.19.2"
+    "axios": "^0.19.2",
+    "bluebird": "^3.7.2"
   }
 }


### PR DESCRIPTION
This PR adds the script to rebuild all Netlify sites.

When the script is run, the following happens
- the script obtains a list of all Netlify site IDs for sites belonging to the `isomer` account
- the script then triggers a new build for each of these Netlify sites.