### PR TITLE
feat(domains): get updated list of domains

### DIFF
--- a/get-list-of-repos/.env-example
+++ b/get-list-of-repos/.env-example
@@ -1,0 +1,1 @@
+export KEYCDN_API_KEY = "enter_secret_here"

--- a/get-list-of-repos/README.md
+++ b/get-list-of-repos/README.md
@@ -9,5 +9,5 @@ Steps to get the updated list:
 2. Enter the query `select "primary_domain_source" from launches`
 3. Export the results that are displayed in a CSV format
 4. Copy paste over the content to db-launches-table.csv
-5. Run `npm get-domains`
+5. Run `npm run get-domains`
 6. Updated list should be at the `Updated__List_of_Domains.csv`

--- a/get-list-of-repos/README.md
+++ b/get-list-of-repos/README.md
@@ -1,0 +1,13 @@
+# Domain List
+
+This script is to get a list of live domains that Isomer has.
+
+Steps to get the updated list:
+
+0. Create a `.env` file and copy over contents from .env-example over + obtain the secret api key directly from 'https://app.keycdn.com/users/authSettings'
+1. Go into the db instance in the reader mode (typically done via tableplus)
+2. Enter the query `select "primary_domain_source" from launches`
+3. Export the results that are displayed in a CSV format
+4. Copy paste over the content to db-launches-table.csv
+5. Run `npm get-domains`
+6. Updated list should be at the `Updated__List_of_Domains.csv`

--- a/get-list-of-repos/get-list-of-domains.js
+++ b/get-list-of-repos/get-list-of-domains.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+require("dotenv").config();
+
+const apiKey = process.env.KEYCDN_API_KEY;
+const apiUrl = "https://api.keycdn.com";
+
+const getKeyCdnDomains = async () => {
+  const response = await fetch(`${apiUrl}/zonealiases.json`, {
+    headers: {
+      Authorization: `Basic ${btoa(apiKey + ":")}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to retrieve zones: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  // Extract the domain names from the zone data
+
+  const domains = data.data.zonealiases
+    .map((zone) => zone.name)
+    .map((zone) => {
+      if (zone.startsWith("www.")) {
+        return zone.substring(4);
+      } else {
+        return zone;
+      }
+    });
+
+  return domains;
+};
+
+function main() {
+  getKeyCdnDomains()
+    .then((domains) => {
+      // read the file and get the domains into a list
+      const dbDomains = fs
+        .readFileSync("db-launches-table.csv", "utf8")
+        .split("\n");
+      domains = domains.filter((domain) => {
+        // There exists some domains that used to be in KeyCDN, but have been migrated out already.
+        return !dbDomains.includes(domain);
+      });
+      const allDomains = [...dbDomains, ...domains];
+      console.log(allDomains);
+      // add this to a csv file
+      fs.writeFileSync("Updated_List_of_Domains.csv", allDomains.join("\n"));
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+}
+main();

--- a/get-list-of-repos/package-lock.json
+++ b/get-list-of-repos/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "get-list-of-repos",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "get-list-of-repos",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    }
+  },
+  "dependencies": {
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+    }
+  }
+}

--- a/get-list-of-repos/package.json
+++ b/get-list-of-repos/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "get-list-of-repos",
+  "version": "1.0.0",
+  "description": "",
+  "main": "get-list-of-domains.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "get-domain": "node get-list-of-domains.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "dotenv": "^16.3.1"
+  }
+}

--- a/get-list-of-repos/package.json
+++ b/get-list-of-repos/package.json
@@ -5,7 +5,7 @@
   "main": "get-list-of-domains.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "get-domain": "node get-list-of-domains.js"
+    "get-domains": "node get-list-of-domains.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Problem 
We have 2 sot for the total lit of domains. Currently, while it is easy for eng to get this info, there is no easy way for ops + prod to do the same.

## Solution 
Get a list of rows directly from table plus. Then get a list of domains from KeyCDN. Then tAll we need to do here is just do a join of these two to get the final output.

## Reviewer notes 
Note: not inclined to improve code style in this PR since this is meant for internal consumption. Specifically seeking feedback if we could make this smoother for ops/prod to get this info easily. 

