### PR TITLE
chore: update clone-repos

### DIFF
--- a/clone-repos/index.js
+++ b/clone-repos/index.js
@@ -68,17 +68,20 @@ const cloneRepository = async (repositoryUrl, destinationPath) => {
 };
 
 async function cloneRepos(orgName) {
-  const repos = await getRepos(orgName);
-  for (let repo of repos) {
-    if (!ISOMER_ADMIN_REPOS.includes(repo.name)) {
+  // const repos = await getRepos(orgName);
+  const allowedRepos = [
+      "isomer-demo",
+    ]
+  for (let repo of allowedRepos) {
+    if (!ISOMER_ADMIN_REPOS.includes(repo)) {
       // Make check for prior existence of repo
-      const repoPath = `${process.env.EFS_VOL_PATH}/${repo.name}`
+      const repoPath = `${process.env.EFS_VOL_PATH}/${repo}`
       if (fs.existsSync(repoPath)) {
-        console.log(`${repo.name} already exists!`)
+        console.log(`${repo} already exists!`)
         continue
       }
-      console.log(`Cloning ${repo.name}`)
-      const repoUrl = `git@github.com:${orgName}/${repo.name}.git`
+      console.log(`Cloning ${repo}`)
+      const repoUrl = `git@github.com:${orgName}/${repo}.git`
       await cloneRepository(repoUrl, repoPath)
     }
   }

--- a/clone-repos/index.js
+++ b/clone-repos/index.js
@@ -68,7 +68,6 @@ const cloneRepository = async (repositoryUrl, destinationPath) => {
 };
 
 async function cloneRepos(orgName) {
-  // const repos = await getRepos(orgName);
   const allowedRepos = [
       "isomer-demo",
     ]


### PR DESCRIPTION
Modifies our cloning script to be based on user specified input - the reason for this is we only want to migrate a smaller number of sites at a time, instead of the entirety of our repos at once, to minimise the chances of users making edits before they get moved onto the ggs flow.