### PR TITLE
feat: add script to cleanup GitHub memberships

### DIFF
--- a/cleanup-github-members/README.md
+++ b/cleanup-github-members/README.md
@@ -1,0 +1,19 @@
+## Cleanup GitHub membership
+
+This script will delete all teams in the organisation that do not have repos attached to them. Thereafter, all members that do not belong to any team will be removed from the organisation.
+
+Ensure that you have your `GITHUB_TOKEN` set up with minimally `admin:org` permissions (so that you can modify org and team memberships).
+
+It is strongly recommended to do a dry run first, to determine if there are any issues with your setup:
+
+```bash
+node index.js --dry-run
+```
+
+The changes made will be logged into `cleanup-github.log`. Any errors will be printed to your terminal and a shorter log will be stored inside `cleanup-github-error.log`.
+
+Once you are confident, delete those 2 files above (if any) and really perform the actions:
+
+```bash
+node index.js --force
+```

--- a/cleanup-github-members/index.js
+++ b/cleanup-github-members/index.js
@@ -1,0 +1,163 @@
+const { Octokit } = require("@octokit/rest");
+const fs = require("fs");
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+  request: {
+    fetch: fetch,
+  },
+});
+
+async function deleteTeam(orgName, teamName) {
+  try {
+    fs.appendFileSync(
+      "cleanup-github.log",
+      `Deleting team ${teamName} from ${orgName}\n`
+    );
+    await octokit.teams.delete({
+      org: orgName,
+      team_slug: teamName,
+    });
+  } catch (err) {
+    console.log(err);
+    fs.appendFileSync(
+      "cleanup-github.log",
+      `Error deleting team ${teamName} from ${orgName}: ${err}\n`
+    );
+  }
+}
+
+async function deleteUserFromOrg(orgName, userName) {
+  try {
+    fs.appendFileSync(
+      "cleanup-github.log",
+      `Deleting user ${userName} from ${orgName}\n`
+    );
+    await octokit.orgs.removeMember({
+      org: orgName,
+      username: userName,
+    });
+  } catch (err) {
+    console.log(err);
+    fs.appendFileSync(
+      "cleanup-github.log",
+      `Error deleting user ${userName} from ${orgName}: ${err}\n`
+    );
+  }
+}
+
+async function getTeams(orgName) {
+  try {
+    const teams = await octokit.paginate(octokit.teams.list, {
+      org: orgName,
+      per_page: 100,
+    });
+    return teams;
+  } catch (err) {
+    console.log(err);
+    fs.appendFileSync(
+      "cleanup-github-error.log",
+      `Error retrieving teams from ${orgName}: ${err}\n`
+    );
+    return null;
+  }
+}
+
+async function getTeamRepos(orgName, teamName) {
+  try {
+    const repos = await octokit.paginate(octokit.teams.listReposInOrg, {
+      org: orgName,
+      team_slug: teamName,
+      per_page: 100,
+    });
+    return repos;
+  } catch (err) {
+    console.log(err);
+    fs.appendFileSync(
+      "cleanup-github-error.log",
+      `Error retrieving repos from ${orgName} for ${teamName}: ${err}\n`
+    );
+    return null;
+  }
+}
+
+async function getUsersInOrg(orgName) {
+  try {
+    const users = await octokit.paginate(octokit.orgs.listMembers, {
+      org: orgName,
+      per_page: 100,
+    });
+    return users;
+  } catch (err) {
+    console.log(err);
+    fs.appendFileSync(
+      "cleanup-github-error.log",
+      `Error retrieving users from ${orgName}: ${err}\n`
+    );
+    return null;
+  }
+}
+
+async function getAllUsersInTeams(orgName) {
+  const teams = await getTeams(orgName);
+  const users = [];
+  for (let team of teams) {
+    try {
+      const teamUsers = await octokit.paginate(octokit.teams.listMembersInOrg, {
+        org: orgName,
+        team_slug: team.name,
+        per_page: 100,
+      });
+      users.push(...teamUsers);
+    } catch (err) {
+      console.log(err);
+      fs.appendFileSync(
+        "cleanup-github-error.log",
+        `Error retrieving users from ${orgName} for ${team.name}: ${err}\n`
+      );
+      return null;
+    }
+  }
+  return users;
+}
+
+async function getTeamsWithNoRepos(orgName) {
+  const teams = await getTeams(orgName);
+  for (let team of teams) {
+    const repos = await getTeamRepos(orgName, team.name);
+    if (repos !== null && repos.length === 0) {
+      // await deleteTeam(orgName, team.name);
+      console.log(`Team ${team.name} has no repos!`);
+      fs.appendFileSync(
+        "cleanup-github-teams.log",
+        `Team ${team.name} has no repos!\n`
+      );
+    }
+  }
+}
+
+async function getUsersWithNoTeams(orgName) {
+  const usersInOrg = await getUsersInOrg(orgName);
+  const usersInTeams = await getAllUsersInTeams(orgName);
+  const usersNotInTeams = usersInOrg.filter(
+    (user) => !usersInTeams.includes(user)
+  );
+  for (let user of usersNotInTeams) {
+    // await deleteUserFromOrg(orgName, user.login);
+    console.log(`User ${user.login} is not in any teams!`);
+    fs.appendFileSync(
+      "cleanup-github-users.log",
+      `User ${user.login} is not in any teams!\n`
+    );
+  }
+}
+
+(async function () {
+  try {
+    // getTeamsWithNoRepos("isomerpages");
+    getUsersWithNoTeams("isomerpages");
+  } catch (err) {
+    console.log(err);
+    process.exit(1);
+  }
+})();

--- a/cleanup-github-members/package-lock.json
+++ b/cleanup-github-members/package-lock.json
@@ -1,0 +1,197 @@
+{
+  "name": "cleanup-github-members",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cleanup-github-members",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@octokit/rest": "^20.0.2"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.1.tgz",
+      "integrity": "sha512-lyeeeZyESFo+ffI801SaBKmCfsvarO+dgV8/0gD8u1d87clbEdWsP5yC+dSj3zLhb2eIf5SJrn6vDz9AheETHw==",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.0.0",
+        "@octokit/request": "^8.0.2",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.2.tgz",
+      "integrity": "sha512-qhKW8YLIi+Kmc92FQUFGr++DYtkx/1fBv+Thua6baqnjnOsgBYJDCvWZR1YcINuHGOEQt416WOfE+A/oG60NBQ==",
+      "dependencies": {
+        "@octokit/types": "^12.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+      "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+      "dependencies": {
+        "@octokit/request": "^8.0.1",
+        "@octokit/types": "^12.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.2.tgz",
+      "integrity": "sha512-8li32fUDUeml/ACRp/njCWTsk5t17cfTM1jp9n08pBrqs5cDFJubtjsSnuz56r5Tad6jdEPJld7LxNp9dNcyjQ=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.2.tgz",
+      "integrity": "sha512-euDbNV6fxX6btsCDnZoZM4vw3zO1nj1Z7TskHAulO6mZ9lHoFTpwll6farf+wh31mlBabgU81bBYdflp0GLVAQ==",
+      "dependencies": {
+        "@octokit/types": "^12.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
+      "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.1.2.tgz",
+      "integrity": "sha512-JztgZ82CY4JNlPTuF0jh4iWuuGpEi5czFCoXyAbMg4F2XyFBbG5DWAKfa3odRvdZww6Df1tQgBKnqpd9X0WF9g==",
+      "dependencies": {
+        "@octokit/types": "^12.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.4.tgz",
+      "integrity": "sha512-M0aaFfpGPEKrg7XoA/gwgRvc9MSXHRO2Ioki1qrPDbl1e9YhjIwVoHE7HIKmv/m3idzldj//xBujcFNqGX6ENA==",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.0",
+        "@octokit/request-error": "^5.0.0",
+        "@octokit/types": "^12.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
+      "integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+      "dependencies": {
+        "@octokit/types": "^12.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.2.tgz",
+      "integrity": "sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==",
+      "dependencies": {
+        "@octokit/core": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.1.1.tgz",
+      "integrity": "sha512-qnJTldJ1NyGT5MTsCg/Zi+y2IFHZ1Jo5+njNCjJ9FcainV7LjuHgmB697kA0g4MjZeDAJsM3B45iqCVsCLVFZg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^19.0.2"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    }
+  }
+}

--- a/cleanup-github-members/package.json
+++ b/cleanup-github-members/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cleanup-github-members",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@octokit/rest": "^20.0.2"
+  }
+}


### PR DESCRIPTION
Script will:
1. Find all teams in organisation that does not have repos attached to them.
2. Delete those teams.
3. Find all organisation members that do not belong to a team.
4. Delete those organisation members from the organisation.

Everything is logged just in case.